### PR TITLE
Add a docker file and docker-compose for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM adoptopenjdk/openjdk12:slim
+
+USER root
+
+RUN apt-get -y upgrade && \
+    apt-get -y update && \
+    apt-get -y install unzip wget

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  local:
+    container_name: app
+    build: .
+    stdin_open: true
+    volumes:
+      - .:/app
+      - gradle_cache:/root/.gradle
+    ports:
+      - "8080:8080"
+      - "5005:5005"
+    working_dir: /app
+    command: bash -c "bash"
+volumes:
+  gradle_cache:


### PR DESCRIPTION
The version of java may not be right but that can be quickly updated in the dockerfile, choosing the proper base-image.