### PR TITLE
change health properties to durations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ Add the following dependency to your `pom.xml`
 <dependency>
     <groupId>com.deviceinsight.kafka</groupId>
     <artifactId>kafka-health-check</artifactId>
-    <version>1.1.0</version>
+    <version>2.0.0-SNAPSHOT</version>
 </dependency>
 ....
 
@@ -30,9 +30,9 @@ An example for an `application.yaml` is:
 kafka:
   health:
     topic: health-checks
-    sendReceiveTimeoutMs: 2500
-    pollTimeoutMs: 200
-    subscriptionTimeoutMs: 5000
+    sendReceiveTimeout: 2.5s
+    pollTimeout: 200ms
+    subscriptionTimeout: 5s
 ....
 
 The values shown are the defaults.
@@ -78,9 +78,9 @@ Now if you call the actuator endpoint `actuator/health` you should see the follo
 |Property |Default |Description
 
 |kafka.health.topic |`health-checks` | Topic to subscribe to
-|kafka.health.sendReceiveTimeoutMs |2500 | The maximum time, in milliseconds, to wait for sending and receiving the message
-|kafka.health.pollTimeoutMs |200 | The time, in milliseconds, spent fetching the data from the topic
-|kafka.health.subscriptionTimeoutMs |5000 | The maximum time, in milliseconds, to wait for subscribing to topic
+|kafka.health.sendReceiveTimeout |2.5s | The maximum time, given as https://docs.spring.io/spring-boot/docs/2.1.9.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config-conversion-duration[Duration], to wait for sending and receiving the message.
+|kafka.health.pollTimeout |200ms | The time, given as https://docs.spring.io/spring-boot/docs/2.1.9.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config-conversion-duration[Duration], spent fetching the data from the topic
+|kafka.health.subscriptionTimeout |5s | The maximum time, given as https://docs.spring.io/spring-boot/docs/2.1.9.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config-conversion-duration[Duration], to wait for subscribing to topic
 
 |===
 

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -1,6 +1,10 @@
 = KafkaHealthCheck
 :icons: font
 
+== Version 2.0.0
+
+* Changed properties to duration type
+
 == Version 1.1.0
 
 * Make consumer groups unique by appending a random UUID when no group ID is configured explicitly.

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -3,7 +3,8 @@
 
 == Version 2.0.0
 
-* Changed properties to duration type
+* Health check timeouts are configured in duration format.
+If you changed the defaults, please adapt your configuration.
 
 == Version 1.1.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
 		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
 		<maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
 		<gitflow-maven-plugin.version>1.12.0</gitflow-maven-plugin.version>
-		<lombok.version>1.18.10</lombok.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.deviceinsight.kafka</groupId>
 	<artifactId>kafka-health-check</artifactId>
-	<version>1.3.0-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Kafka Health Check</name>
@@ -36,6 +36,7 @@
 		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
 		<maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
 		<gitflow-maven-plugin.version>1.12.0</gitflow-maven-plugin.version>
+		<lombok.version>1.18.10</lombok.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/com/deviceinsight/kafka/health/KafkaConsumingHealthIndicator.java
+++ b/src/main/java/com/deviceinsight/kafka/health/KafkaConsumingHealthIndicator.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -83,7 +82,7 @@ public class KafkaConsumingHealthIndicator extends AbstractHealthIndicator {
 		this.executor = Executors.newSingleThreadExecutor();
 		this.running = new AtomicBoolean(true);
 		this.cache =
-				Caffeine.newBuilder().expireAfterWrite(sendReceiveTimeout.toMillis(), TimeUnit.MILLISECONDS).build();
+				Caffeine.newBuilder().expireAfterWrite(sendReceiveTimeout).build();
 
 		this.kafkaCommunicationResult =
 				KafkaCommunicationResult.failure(new RejectedExecutionException("Kafka Health Check is starting."));

--- a/src/main/java/com/deviceinsight/kafka/health/KafkaConsumingHealthIndicator.java
+++ b/src/main/java/com/deviceinsight/kafka/health/KafkaConsumingHealthIndicator.java
@@ -205,7 +205,7 @@ public class KafkaConsumingHealthIndicator extends AbstractHealthIndicator {
 					goDown(builder);
 				} else {
 					builder.down(new TimeoutException(
-							"Sending and receiving took longer than " + sendReceiveTimeout + " ms"))
+							"Sending and receiving took longer than " + sendReceiveTimeout ))
 							.withDetail("topic", topic);
 				}
 

--- a/src/main/java/com/deviceinsight/kafka/health/KafkaHealthProperties.java
+++ b/src/main/java/com/deviceinsight/kafka/health/KafkaHealthProperties.java
@@ -1,11 +1,13 @@
 package com.deviceinsight.kafka.health;
 
+import java.time.Duration;
+
 public class KafkaHealthProperties {
 
 	private String topic = "health-checks";
-	private long sendReceiveTimeoutMs = 2500;
-	private long pollTimeoutMs = 200;
-	private long subscriptionTimeoutMs = 5000;
+	private Duration sendReceiveTimeout = Duration.ofMillis(2500);
+	private Duration pollTimeout = Duration.ofMillis(200);
+	private Duration subscriptionTimeout = Duration.ofSeconds(5);
 
 	public String getTopic() {
 		return topic;
@@ -15,27 +17,33 @@ public class KafkaHealthProperties {
 		this.topic = topic;
 	}
 
-	public long getSendReceiveTimeoutMs() {
-		return sendReceiveTimeoutMs;
+	public Duration getSendReceiveTimeout() {
+		return sendReceiveTimeout;
 	}
 
-	public void setSendReceiveTimeoutMs(long sendReceiveTimeoutMs) {
-		this.sendReceiveTimeoutMs = sendReceiveTimeoutMs;
+	public void setSendReceiveTimeout(Duration sendReceiveTimeout) {
+		this.sendReceiveTimeout = sendReceiveTimeout;
 	}
 
-	public long getPollTimeoutMs() {
-		return pollTimeoutMs;
+	public Duration getPollTimeout() {
+		return pollTimeout;
 	}
 
-	public void setPollTimeoutMs(long pollTimeoutMs) {
-		this.pollTimeoutMs = pollTimeoutMs;
+	public void setPollTimeout(Duration pollTimeout) {
+		this.pollTimeout = pollTimeout;
 	}
 
-	public long getSubscriptionTimeoutMs() {
-		return subscriptionTimeoutMs;
+	public Duration getSubscriptionTimeout() {
+		return subscriptionTimeout;
 	}
 
-	public void setSubscriptionTimeoutMs(long subscriptionTimeoutMs) {
-		this.subscriptionTimeoutMs = subscriptionTimeoutMs;
+	public void setSubscriptionTimeout(Duration subscriptionTimeout) {
+		this.subscriptionTimeout = subscriptionTimeout;
+	}
+
+	@Override
+	public String toString() {
+		return "KafkaHealthProperties{" + "topic='" + topic + '\'' + ", sendReceiveTimeout=" + sendReceiveTimeout +
+				", pollTimeout=" + pollTimeout + ", subscriptionTimeout=" + subscriptionTimeout + '}';
 	}
 }


### PR DESCRIPTION
Sprint boot supports durations. Therefore there is no reason to use milisecond based properties anymore