### PR TITLE
Add Spring Boot auto configuration of actuator

### DIFF
--- a/src/main/java/com/deviceinsight/kafka/health/KafkaHealthAutoConfiguration.java
+++ b/src/main/java/com/deviceinsight/kafka/health/KafkaHealthAutoConfiguration.java
@@ -1,0 +1,30 @@
+package com.deviceinsight.kafka.health;
+
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnClass(AbstractHealthIndicator.class)
+public class KafkaHealthAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(KafkaHealthProperties.class)
+  @ConfigurationProperties("kafka.health")
+  public KafkaHealthProperties kafkaHealthProperties() {
+    return new KafkaHealthProperties();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(KafkaConsumingHealthIndicator.class)
+  public KafkaConsumingHealthIndicator kafkaConsumingHealthIndicator(KafkaHealthProperties kafkaHealthProperties,
+      KafkaProperties processingProperties) {
+    return new KafkaConsumingHealthIndicator(kafkaHealthProperties, processingProperties.buildConsumerProperties(),
+        processingProperties.buildProducerProperties());
+  }
+
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.deviceinsight.kafka.health.KafkaHealthAutoConfiguration


### PR DESCRIPTION
Added auto configuration of the KafkaHealthProperties and KafkaConsumingHealthIndicator beans, as long as they've not already been instantiated.

The entire auto configuration is conditional on AbstractHealthIndicator, which would be missing if the importing project would not have spring-boot-actuator-starter on its classpath.

Fixes #9 